### PR TITLE
Saving all annotations in each AnnotationSignal

### DIFF
--- a/EDF/EDFWriter.cs
+++ b/EDF/EDFWriter.cs
@@ -170,15 +170,24 @@ namespace EDFCSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteAnnotations(int index, List<TAL> annotations, int sampleCountPerRecord)
         {
+            var blockSize = sampleCountPerRecord * 2;
+
             var bytesWritten = 0;
             bytesWritten += WriteAnnotationIndex(index);
-            if (index < annotations.Count)
+            while (index < annotations.Count)
             {
+                // Ensure that the TAL does not span more than a single Data Record
+                var bytesToWrite = TALExtensions.GetByteSize( annotations[ index ] );
+                if( bytesWritten + bytesToWrite > blockSize )
+                {
+                    break;
+                }
+
                 bytesWritten += WriteAnnotation(annotations[index]);
+                index        += 1;
             }
 
             //Fills block size left with 0
-            var blockSize = sampleCountPerRecord * 2;
 #if TRACE_BYTES
             Debug.WriteLine($"Total bytes for Annotation index {0} is {bytesWritten}");
 #endif

--- a/EDF/TAL.cs
+++ b/EDF/TAL.cs
@@ -13,7 +13,7 @@ namespace EDFCSharp
     /// </summary>
     public class TAL
     {
-        private const string StringDoubleFormat = "0.###";
+        private const string StringDoubleFormat = "0.########";
         /// <summary>
         /// Character used for separating onset and duration
         /// </summary>

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -143,10 +143,24 @@ namespace EDFSharpTests
 
             string file2 = "test2.edf";
             edf.Save(file2);
+
             var edf2 = new EDFFile(file2);
-            Assert.IsTrue(edf2.Header.Equals(edf.Header));
-            Assert.IsTrue(edf2.Signals.SequenceEqual(edf.Signals));
-            Assert.IsTrue(edf2.AnnotationSignals.SequenceEqual(edf.AnnotationSignals));
+            Assert.IsTrue( edf2.Header.Equals( edf.Header ),          "Saved Header does not match original" );
+            Assert.IsTrue( edf2.Signals.SequenceEqual( edf.Signals ), "Saved Signals do not match original" );
+            Assert.AreEqual( edf.AnnotationSignals.Count, edf2.AnnotationSignals.Count, "Saved file contains a different number of Annotation Signals than original." );
+            
+            for( int i = 0; i < edf.AnnotationSignals.Count; i++ )
+            {
+                var original = edf.AnnotationSignals[ i ];
+                var compare  = edf2.AnnotationSignals[ i ];
+
+                Assert.IsTrue( original.SamplesCount == compare.SamplesCount, "Annotation signals contain a differing number of samples" );
+
+                for( int j = 0; j < original.SamplesCount; j++ )
+                {
+                    Assert.AreEqual( original.Samples[ j ].ToString().Trim(), compare.Samples[ j ].ToString().Trim(), false, "Stored Annotation samples differ" );
+                }
+            }
         }
         [TestMethod]
         public void ReadAnnotationAndSignalsFile()


### PR DESCRIPTION
Now successfully saves all annotations per AnnotationSignal (previously stopped at the first one). 
Numerical precision for TAL.StartSecondsString increased to eight fractional digits. 
ReadAndSaveAnnotationOnlyFile() unit test now passing. 