### PR TITLE
Saving Annotations

### DIFF
--- a/EDF/EDF.csproj
+++ b/EDF/EDF.csproj
@@ -5,11 +5,11 @@
 		<AssemblyTitle>EDFCSharp</AssemblyTitle>
 		<AssemblyName>EDFCSharp</AssemblyName>
 		<RootNamespace>EDFCSharp</RootNamespace>
-		<Company>Lior Banai</Company>
-		<Product>EDF</Product>
-		<Version>0.6.2</Version>
+		<Company>StagPoint</Company>
+		<Product>StagPoint.EDF.NET</Product>
+		<Version>0.6.3</Version>
 		<Description>Read and write EDF signal files.</Description>
-		<Copyright>Copyright © 2022</Copyright>
+		<Copyright>Copyright © 2023</Copyright>
 		<SignAssembly>false</SignAssembly>
 		<DelaySign>false</DelaySign>
 		<Platforms>AnyCPU;x86;x64</Platforms>
@@ -18,7 +18,7 @@
 		<Company>LiorBanai</Company>
 		<Product>EDF-CSharp</Product>
 		<Description>C# Implementation of the EDF (European Data Format) Format</Description>
-		<Copyright>Lior Banai @ 2020-2022</Copyright>
+		<Copyright>Lior Banai @ 2020-2022, subsequent changes StagPoint 2023</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/LiorBanai/EDF</PackageProjectUrl>
 		<PackageIcon>EDFCSharp.png</PackageIcon>

--- a/EDF/EDF.csproj
+++ b/EDF/EDF.csproj
@@ -5,25 +5,23 @@
 		<AssemblyTitle>EDFCSharp</AssemblyTitle>
 		<AssemblyName>EDFCSharp</AssemblyName>
 		<RootNamespace>EDFCSharp</RootNamespace>
-		<Company>StagPoint</Company>
-		<Product>StagPoint.EDF.NET</Product>
 		<Version>0.6.3</Version>
 		<Description>Read and write EDF signal files.</Description>
 		<Copyright>Copyright © 2023</Copyright>
 		<SignAssembly>false</SignAssembly>
 		<DelaySign>false</DelaySign>
 		<Platforms>AnyCPU;x86;x64</Platforms>
-		<PackageId>EDF-CSharp</PackageId>
-		<Authors>LiorBanai</Authors>
-		<Company>LiorBanai</Company>
-		<Product>EDF-CSharp</Product>
+		<PackageId>StagPoint.EDF.Net</PackageId>
+		<Authors>StagPoint</Authors>
+		<Company>StagPoint</Company>
+		<Product>StagPoint.EDF.Net</Product>
 		<Description>C# Implementation of the EDF (European Data Format) Format</Description>
 		<Copyright>Lior Banai @ 2020-2022, subsequent changes StagPoint 2023</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/LiorBanai/EDF</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/StagPoint/StagPoint.EDF.NET</PackageProjectUrl>
 		<PackageIcon>EDFCSharp.png</PackageIcon>
 		<PackageIconUrl />
-		<RepositoryUrl>https://github.com/LiorBanai/EDF</RepositoryUrl>
+		<RepositoryUrl>https://github.com/StagPoint/StagPoint.EDF.NET</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageReleaseNotes>initial version</PackageReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -36,6 +34,7 @@
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<LangVersion>8</LangVersion>
 		<PackageTags>EDF;European Data Format</PackageTags>
+		<Title>EDF-CSharp - Read/Write European Data Format Files</Title>
 	</PropertyGroup>
 	<ItemGroup>
 	  <Content Include="EDFCSharp.ico" />

--- a/EDF/EDFFile.cs
+++ b/EDF/EDFFile.cs
@@ -20,7 +20,7 @@ namespace EDFCSharp
         public EDFSignal[] Signals { get; private set; }
         public List<AnnotationSignal> AnnotationSignals { get; private set; }
         public List<TAL> AllAnnotations => AnnotationSignals.SelectMany(a => a.Samples).ToList();
-        private Reader Reader { get; set; }
+        private EDFReader Reader { get; set; }
 
         public EDFFile()
         {
@@ -78,7 +78,7 @@ namespace EDFCSharp
         public void Open(string filePath)
         {
             // Open file
-            Reader = new Reader(File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read));
+            Reader = new EDFReader(File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read));
             Header = Reader.ReadHeader();
             Signals = Reader.AllocateSignals(Header);
         }
@@ -111,7 +111,7 @@ namespace EDFCSharp
 
         public static EDFHeader ReadHeader(string filename)
         {
-            using (var reader = new Reader(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            using (var reader = new EDFReader(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read)))
             {
                 return reader.ReadHeader();
             }
@@ -122,7 +122,7 @@ namespace EDFCSharp
         /// <param name="edfFilePath"></param>
         public void ReadAll(string edfFilePath)
         {
-            using (var reader = new Reader(File.Open(edfFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            using (var reader = new EDFReader(File.Open(edfFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)))
             {
                 Header = reader.ReadHeader();
                 var result = reader.ReadSignals(Header);
@@ -137,7 +137,7 @@ namespace EDFCSharp
         /// <param name="edfBytes"></param>
         public void ReadAll(byte[] edfBytes)
         {
-            using (var reader = new Reader(edfBytes))
+            using (var reader = new EDFReader(edfBytes))
             {
                 Header = reader.ReadHeader();
                 var result = reader.ReadSignals(Header);

--- a/EDF/EDFReader.cs
+++ b/EDF/EDFReader.cs
@@ -11,10 +11,10 @@ namespace EDFCSharp
     /// <summary>
     /// EDF+ file reader
     /// </summary>
-    internal class Reader : BinaryReader
+    internal class EDFReader : BinaryReader
     {
-        public Reader(FileStream fs) : base(fs) { }
-        public Reader(byte[] edfBytes) : base(new MemoryStream(edfBytes)) { }
+        public EDFReader(FileStream fs) : base(fs) { }
+        public EDFReader(byte[] edfBytes) : base(new MemoryStream(edfBytes)) { }
 
         public EDFHeader ReadHeader()
         {

--- a/EDF/EDFWriter.cs
+++ b/EDF/EDFWriter.cs
@@ -170,15 +170,24 @@ namespace EDFCSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteAnnotations(int index, List<TAL> annotations, int sampleCountPerRecord)
         {
+            var blockSize = sampleCountPerRecord * 2;
+
             var bytesWritten = 0;
             bytesWritten += WriteAnnotationIndex(index);
-            if (index < annotations.Count)
+            while (index < annotations.Count)
             {
+                // Ensure that the TAL does not span more than a single Data Record
+                var bytesToWrite = TALExtensions.GetByteSize( annotations[ index ] );
+                if( bytesWritten + bytesToWrite > blockSize )
+                {
+                    break;
+                }
+
                 bytesWritten += WriteAnnotation(annotations[index]);
+                index        += 1;
             }
 
             //Fills block size left with 0
-            var blockSize = sampleCountPerRecord * 2;
 #if TRACE_BYTES
             Debug.WriteLine($"Total bytes for Annotation index {0} is {bytesWritten}");
 #endif

--- a/EDF/EDFWriter.cs
+++ b/EDF/EDFWriter.cs
@@ -30,35 +30,65 @@ namespace EDFCSharp
             WriteItem(edf.Header.RecordDurationInSeconds);
             WriteItem(edf.Header.NumberOfSignalsInRecord);
 
+            // When re-saving an existing file, there will already be a Signal file corresponding 
+            // to the Annotations in the Signals array. However, when saving a new file with annotations, 
+            // that dummy Signal will not exist, so we will need to concatenate all of the appropriate 
+            // fields. This is an artifact of how the design of the library separates regular Signals and 
+            // AnnotationSignals into similar but uncompatible types, and would be better resolved by
+            // unifying that design, but this workaround gets the job done. 
+            bool concatAnnotationsSignal = 
+                edf.AnnotationSignals.Count > 0 && 
+                !edf.Signals.Any(s => s.Label.Value.Equals(EDFConstants.AnnotationLabel));
+
             //----------------- Variable length header items -----------------
             var headerSignalsLabel = edf.Signals.Select(s => s.Label);
+            if( concatAnnotationsSignal )
+                headerSignalsLabel = headerSignalsLabel.Concat(edf.AnnotationSignals.Select(s => s.Label));
             WriteItem(headerSignalsLabel);
             
             var trandsducerTypes = edf.Signals.Select(s => s.TransducerType);
-            WriteItem(trandsducerTypes);
+			if (concatAnnotationsSignal)
+				trandsducerTypes = trandsducerTypes.Concat(edf.AnnotationSignals.Select(s => s.TransducerType));
+			WriteItem(trandsducerTypes);
 
             var physicalDimensions = edf.Signals.Select(s => s.PhysicalDimension);
-            WriteItem(physicalDimensions);
+			if (concatAnnotationsSignal)
+				physicalDimensions = physicalDimensions.Concat(edf.AnnotationSignals.Select(s => s.PhysicalDimension));
+			WriteItem(physicalDimensions);
 
             var physicalMinimums = edf.Signals.Select(s => s.PhysicalMinimum);
-            WriteItem(physicalMinimums);
+			if (concatAnnotationsSignal)
+				physicalMinimums = physicalMinimums.Concat(edf.AnnotationSignals.Select(s => s.PhysicalMinimum));
+			WriteItem(physicalMinimums);
 
             var physicalMaximuns = edf.Signals.Select(s => s.PhysicalMaximum);
-            WriteItem(physicalMaximuns);
+			if (concatAnnotationsSignal)
+				physicalMaximuns = physicalMaximuns.Concat(edf.AnnotationSignals.Select(s => s.PhysicalMaximum));
+			WriteItem(physicalMaximuns);
 
             var digitalMinimuns = edf.Signals.Select(s => s.DigitalMinimum);
+			if (concatAnnotationsSignal)
+				digitalMinimuns = digitalMinimuns.Concat(edf.AnnotationSignals.Select(s => s.DigitalMinimum));
             WriteItem(digitalMinimuns);
 
             var digitalMaximuns = edf.Signals.Select(s => s.DigitalMaximum);
+			if (concatAnnotationsSignal)
+				digitalMaximuns = digitalMaximuns.Concat(edf.AnnotationSignals.Select(s => s.DigitalMaximum));
             WriteItem(digitalMaximuns);
 
             var prefilterings = edf.Signals.Select(s => s.Prefiltering);
-            WriteItem(prefilterings);
+			if (concatAnnotationsSignal)
+				prefilterings = prefilterings.Concat(edf.AnnotationSignals.Select(s => s.Prefiltering));
+			WriteItem(prefilterings);
 
             var samplesCountPerRecords = edf.Signals.Select(s => s.NumberOfSamplesInDataRecord);
+			if (concatAnnotationsSignal)
+				samplesCountPerRecords = samplesCountPerRecords.Concat(edf.AnnotationSignals.Select(s => s.NumberOfSamplesInDataRecord));
             WriteItem(samplesCountPerRecords);
 
             var reservedValues = edf.Signals.Select(s => s.Reserved);
+			if (concatAnnotationsSignal)
+				reservedValues = reservedValues.Concat(edf.AnnotationSignals.Select(s => s.Reserved));
             WriteItem(reservedValues);
 
             Debug.WriteLine("Writer position after header: " + BaseStream.Position);

--- a/EDF/PatientIdentification.cs
+++ b/EDF/PatientIdentification.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EDFCSharp
+{
+	/// <summary>
+	/// Used to encode EDF+ patient identification subfields into Header.PatientID
+	/// </summary>
+	public class PatientIdentification
+	{
+		#region Public properties 
+
+		public string Code { get; set; }
+		public string Sex { get; set; }
+		public DateTime? BirthDate { get; set; }
+		public string PatientName { get; set; }
+
+		public List<KeyValuePair<string,string>> AdditionalSubfields { get; set;  }
+
+		#endregion
+
+		#region Constructors 
+
+		public PatientIdentification()
+		{
+			AdditionalSubfields = new List<KeyValuePair<string, string>>();
+		}
+
+		public PatientIdentification( string Code, string Sex, DateTime? BirthDate, string PatientName)
+		{
+			this.Code = Code;
+			this.Sex = Sex;
+			this.BirthDate = BirthDate;
+			this.PatientName = PatientName;
+
+			AdditionalSubfields = new List<KeyValuePair<string, string>>();
+		}
+
+		#endregion
+
+		#region Public functions 
+
+		public void AddField( string key, string value )
+		{
+			AdditionalSubfields.Add(new KeyValuePair<string, string>(key, value));
+		}
+
+		public static PatientIdentification Parse(string buffer, bool throwOnFormatInvalid = true)
+		{
+			if (TryParse(buffer, out PatientIdentification result))
+			{
+				return result;
+			}
+
+			if (throwOnFormatInvalid)
+			{
+				throw new FormatException($"The value '{buffer}' does not appear to be a valid format for {nameof(PatientIdentification)}");
+			}
+
+			return null;
+		}
+
+		public static bool TryParse( string buffer, out PatientIdentification result )
+		{
+			result = null;
+
+			var parts = buffer.Split(' ');
+			if ( parts.Length < 4 ) 
+			{  
+				return false; 
+			}
+
+			string code = parts[0].Replace( '_', ' ' ); 
+			string sex = parts[1].Substring( 0, 1 );
+			string patientName = parts[3].Replace('_', ' ');
+			DateTime? birthDate = null;
+
+			if (string.Compare(parts[2], "X", true) != 0)
+			{
+				if (!DateTime.TryParse(parts[2], out DateTime parsedDate))
+				{
+					return false;
+				}
+				birthDate = parsedDate;
+			}
+
+			if( string.Compare(code, "X", StringComparison.Ordinal ) == 0 ) { code = string.Empty; }
+			if( string.Compare(sex, "X", StringComparison.Ordinal) == 0 ) { sex = string.Empty; }
+			if( string.Compare(patientName, "X", StringComparison.Ordinal) == 0 ) { patientName = string.Empty; }
+
+			var additionalFields = new List<KeyValuePair<string, string>>( parts.Length - 4 );
+
+			for (int i = 4; i < parts.Length; i++)
+			{
+				var field = parts[i];
+
+				int splitPos = field.IndexOf('=');
+				if( splitPos == -1 )
+				{
+					return false;
+				}
+
+				var newPair = new KeyValuePair<string, string>(
+					field.Substring(0, splitPos).Replace( '_', ' ' ), 
+					field.Substring(splitPos + 1).Replace('_', ' ')
+					);
+
+				additionalFields.Add( newPair );
+			}
+
+			result = new PatientIdentification(code, sex, birthDate, patientName)
+			{
+				AdditionalSubfields = additionalFields
+			};
+
+			return true;
+        }
+
+		#endregion
+
+		#region Base type overrides 
+
+		public override string ToString()
+		{
+			var buffer = new StringBuilder();
+
+			buffer.Append(string.IsNullOrEmpty(Code) ? "X" : Code?.Replace(' ', '_'));
+			buffer.Append(' ');
+
+			buffer.Append(string.IsNullOrEmpty(Sex) ? "X" : Sex?.Substring(0, 1));
+			buffer.Append(' ');
+
+			buffer.Append(BirthDate?.ToString("dd-MMM-yyyy") ?? "X");
+			buffer.Append(' ');
+
+			buffer.Append(string.IsNullOrEmpty(PatientName) ? "X" : PatientName?.Replace(' ', '_'));
+
+			foreach( var pair in AdditionalSubfields )
+			{
+				buffer.Append(' ');
+				buffer.Append(pair.Key.Replace(' ', '_'));
+				buffer.Append('=');
+				buffer.Append(pair.Value.Replace(' ', '_'));
+			}
+
+			return buffer.ToString();
+		}
+
+		#endregion
+
+		#region Implicit Type Conversion 
+
+		public static implicit operator FixedLengthString( PatientIdentification value )
+		{
+			return new FixedLengthString(HeaderItems.PatientID) 
+			{  
+				Value = value.ToString() 
+			};	
+		}
+
+		public static implicit operator PatientIdentification( FixedLengthString value )
+		{
+			return Parse(value.Value);
+		}
+
+		#endregion
+	}
+}

--- a/EDF/TAL.cs
+++ b/EDF/TAL.cs
@@ -13,7 +13,7 @@ namespace EDFCSharp
     /// </summary>
     public class TAL
     {
-        private const string StringDoubleFormat = "0.###";
+        private const string StringDoubleFormat = "0.########";
         /// <summary>
         /// Character used for separating onset and duration
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Support for writing was left in place but is untested and most certainly broken.
 This project is provided under the terms of the [MIT license](http://choosealicense.com/licenses/mit/).
 
 # Binary Distribution
-The easiest way to make use of this library in your own project is to add a reference to the following [NuGet package](https://www.nuget.org/packages/EDF-CSharp/).
+The easiest way to make use of this library in your own project is to add a reference to the following [NuGet package](https://www.nuget.org/packages/StagPoint.EDF.Net/).
 
 # European Data Format
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 <h1 align="center">EDF-CSharp: C# EDF Implementation <img src="./Assets/EDF.png" align="right" width="155px" height="155px"></h1> 
 
-[![.NET Core Desktop](https://github.com/LiorBanai/EDF/actions/workflows/dotnet-desktop.yml/badge.svg)](https://github.com/LiorBanai/EDF/actions/workflows/dotnet-desktop.yml)
-<a href="https://github.com/LiorBanai/EDF/issues">
-    <img src="https://img.shields.io/github/issues/LiorBanai/EDF"  alt="Issues"/>
-</a> ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/LiorBanai/EDF)
-<a href="https://github.com/LiorBanai/EDF/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/LiorBanai/EDF"  alt="License"/>
-</a>
-[![Nuget](https://img.shields.io/nuget/v/EDF-CSharp)](https://www.nuget.org/packages/EDF-CSharp/)
-[![Nuget](https://img.shields.io/nuget/dt/EDF-CSharp)](https://www.nuget.org/packages/EDF-CSharp/) [![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/donate/?business=MCP57TBRAAVXA&no_recurring=0&item_name=Support+Open+source+Projects+%28Analogy+Log+Viewer%2C+HDF5-CSHARP%2C+etc%29&currency_code=USD) [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/F1F77IVQT)
-
-
 # Summary
 
 SharpLibEuropeanDataFormat allows you to read EDF files typically used in medical applications.

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -143,10 +143,24 @@ namespace EDFSharpTests
 
             string file2 = "test2.edf";
             edf.Save(file2);
+
             var edf2 = new EDFFile(file2);
-            Assert.IsTrue(edf2.Header.Equals(edf.Header));
-            Assert.IsTrue(edf2.Signals.SequenceEqual(edf.Signals));
-            Assert.IsTrue(edf2.AnnotationSignals.SequenceEqual(edf.AnnotationSignals));
+            Assert.IsTrue( edf2.Header.Equals( edf.Header ),          "Saved Header does not match original" );
+            Assert.IsTrue( edf2.Signals.SequenceEqual( edf.Signals ), "Saved Signals do not match original" );
+            Assert.AreEqual( edf.AnnotationSignals.Count, edf2.AnnotationSignals.Count, "Saved file contains a different number of Annotation Signals than original." );
+            
+            for( int i = 0; i < edf.AnnotationSignals.Count; i++ )
+            {
+                var original = edf.AnnotationSignals[ i ];
+                var compare  = edf2.AnnotationSignals[ i ];
+
+                Assert.IsTrue( original.SamplesCount == compare.SamplesCount, "Annotation signals contain a differing number of samples" );
+
+                for( int j = 0; j < original.SamplesCount; j++ )
+                {
+                    Assert.AreEqual( original.Samples[ j ].ToString().Trim(), compare.Samples[ j ].ToString().Trim(), false, "Stored Annotation samples differ" );
+                }
+            }
         }
         [TestMethod]
         public void ReadAnnotationAndSignalsFile()


### PR DESCRIPTION
Includes various changes to allow saving all annotations. 

Previously, the library would only save a single TAL per _AnnotationSignal_ (see [Issue #11](https://github.com/LiorBanai/EDF/issues/11#issuecomment-1215126313)), at least with newly-created files (the behavior was different when re-saving an existing EDF file with annotations). 

Additionally, the _ReadAndSaveAnnotationOnlyFile()_ unit test was failing. With these changes, that unit test is now passing. 